### PR TITLE
feat: set persist-credentials default to false for better security

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
     default: git
   persist-credentials:
     description: 'Whether to configure the token or SSH key with the local git config'
-    default: true
+    default: false # Avoids leaking GitHub token by not saving it to git config
   path:
     description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
   clean:


### PR DESCRIPTION
## Summary

This changes the default value of the `persist-credentials` input to `false` in order to improve security when wrapping `actions/checkout`.

By not writing the GitHub token into `.git/config`, we reduce the risk of:

- Accidental exposure of the token via local git logs or shared directories
- Unintended reuse of the token in subsequent Git operations
- Credential leakage in containers or reused environments

## Background

The original default (`true`) was convenient but potentially risky, especially in multi-step or shared-runner workflows. Setting it to `false` aligns with the principle of least privilege and reduces the attack surface.

Users who explicitly require GitHub token persistence can still set `persist-credentials: true` manually.

## Impact

This is a **breaking change** for users who implicitly relied on the default behavior.

## Rationale

This change reflects a common concern raised by the community regarding the security implications of persisting credentials by default.

Although this issue has been discussed in the official `actions/checkout` repository ([actions/checkout#485](https://github.com/actions/checkout/issues/485)), no progress has been made in changing the default behavior upstream. As a result, this wrapper action explicitly sets `persist-credentials: false` by default to enforce a more secure baseline.
